### PR TITLE
[新 SIG 提案] Next Electron Wrapper

### DIFF
--- a/sig/next-electron-wrapper/MEMBERS.md
+++ b/sig/next-electron-wrapper/MEMBERS.md
@@ -1,0 +1,7 @@
+## Team Members
+
+- [ziggy1030](https://github.com/ziggy1030)
+- [superliya](https://github.com/superliya)
+- [Oyami-Srk](https://github.com/Oyami-Srk)
+- [dong8yong8](https://github.com/dong8yong8)
+- [mahaochun](https://github.com/mhc2910463910)

--- a/sig/next-electron-wrapper/README.md
+++ b/sig/next-electron-wrapper/README.md
@@ -1,0 +1,42 @@
+# Next Electron Wrapper
+---
+
+## 小组简介
+`Electron Wrapper Next toolchains`用来包装任何一个网页到一个Electron应用。
+在结合本地npm缓存下,仅需数分钟即可产出任何一个网页封装之后的Electron二进制程序!
+
+本项目是[Electron wrapper by Oyami-Srk](https://github.com/shirodeb/electron-wrapper)的正统精神传承，并承诺永久开源
+
+## 小组活动范围及目标
+
+- 完善Next Electron Wrapper的本体程序,并完成ToDo功能的加入.
+- 开展玲珑构建任务适配,使该套件构建完成的Electron程序可以更方便转换为玲珑应用包.
+- 与其他社区开展交流合作,将本项目的技术成果共享到其他开源社区中并为开源应用生态提供贡献.
+
+## 会议与活动
+  我们不定期举行会议和活动，包括：
+- **SIG月会**：每月不定期讨论生态进展和计划。
+- **技术沙龙**：不定期深入探讨特定技术问题。也期待贡献者主动发起技术沙龙会议。
+
+## 讨论渠道
+- 小组SIG仓库
+
+## 相关资源
+- Next Electron Wrapper toolchains使用文档
+- Next Electron Wrapper toolchains 运用实例
+
+## 参与SIG的方法
+  我们欢迎所有对Linux应用开发充满热情的开发者加入。
+  但我们期望你能够具备一定的shell阅读编写及自动化流程设计能力，程序运行逻辑、思路清晰者更佳。
+  可以通过以下流程加入我们的SIG:
+
+1. 在SIG专有仓库中提交Issues 说明想加入的原因
+  \*加入之后会在成员列表进行公示
+
+## 相关链接
+
+
+
+
+
+

--- a/sig/next-electron-wrapper/metadata.yml
+++ b/sig/next-electron-wrapper/metadata.yml
@@ -1,0 +1,28 @@
+---
+name: Next Electron Wrapper
+blog: 
+rss: 
+matrix: 
+proposal:
+  by:
+    handle: ziggy1030
+    id: 39146681
+date-created: '2024/10/10'
+date-archived: '-'
+team: next-electron-wrapper
+repos:
+  maintained:
+  package:
+    - sig-next-electron-wrapper
+members:
+  - handle: ziggy1030
+    id: 39146681
+  - handle: superliya
+    id: 176374226
+  - handle: dong8yong8
+    id: 18693492
+  - handle: Oyami-Srk
+    id: 6939913
+  - handle: mhc2910463910
+    id: 101699371
+


### PR DESCRIPTION
## SIG 创建原因

`Electron Wrapper Next toolchains`用来包装任何一个网页到一个Electron应用.我们致力于与其他社区开展交流合作,将本项目的技术成果共享到其他开源社区中并为开源应用生态提供贡献.

## 仓库创建

此 SIG 需在 OpenAtom-Linyaps 组织下创建如下仓库：

- sig-next-electron-wrapper
